### PR TITLE
Fix ESP32 send sample rate when configured on I2S1

### DIFF
--- a/examples/ESP32Send/ESP32Send.ino
+++ b/examples/ESP32Send/ESP32Send.ino
@@ -244,5 +244,14 @@ void setupAudioOutput(int sample_rate)
     while (true);
   }
 
+  /*
+   * Known Issue
+   * The output sample rate is not correct if I2S0 is not configured
+   * This can be removed if receiving is set up on I2S0.
+   */
+  i2s_config_t i2s_config_stub = i2s_config;
+  i2s_config_stub.bits_per_sample = I2S_BITS_PER_SAMPLE_32BIT;
+  i2s_driver_install(I2S_NUM_0, &i2s_config_stub, 0, NULL);
+
   Serial.println("Audio output driver initalised.");
 }


### PR DESCRIPTION
The send functionality doesn't work when configured without RX on I2S0. It seems to run at half the sample rate. 

I'm proposing this as a quick hack to get around the issue. 

Let me know if you have any suggestions...